### PR TITLE
approxCollateral fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - pip install -r requirements-dev.txt
 
 script:
-  - "./.ci/leaks.sh && ./test.sh"
+  - "./test.sh"
 
 after_success:
   - codecov

--- a/auction_keeper/strategy.py
+++ b/auction_keeper/strategy.py
@@ -142,6 +142,7 @@ class FixedDiscountCollateralAuctionStrategy(Strategy):
         self.min_amount_to_sell = min_amount_to_sell
         self.geb = geb
         self.our_address = our_address
+        self.last_redemption_price = Wad(0)
 
     def approve(self, gas_price: GasPrice):
         assert isinstance(gas_price, GasPrice)
@@ -191,9 +192,14 @@ class FixedDiscountCollateralAuctionStrategy(Strategy):
             self.logger.info(f"Our system coin balance is less than FixedDiscountCollateralAucttionHouse.minimum_bid(). Not bidding")
             return None, None, None
 
+        if self.last_redemption_price == Wad(0):
+            assert self.collateral_auction_house.get_collateral_bought(id, our_bid).transact()
+            self.last_redemption_price = self.collateral_auction_house.last_read_redemption_price()
+
         approximate_collateral, our_adjusted_bid = self.collateral_auction_house.get_approximate_collateral_bought(id, our_bid)
+
         if approximate_collateral == Wad(0):
-            self.logger.info(f"Approximate collateral bought would be Wad(0). Not bidding")
+            self.logger.info(f"Approximate collateral bought for auction {id} would be Wad(0). Not bidding")
             return None, None, None
         our_approximate_price = our_adjusted_bid/approximate_collateral
 


### PR DESCRIPTION
Keeper checks if `FixedDiscountCollateralAuctionHouse.lastReadRedemptionPrice` is zero before calling `getApproximateCollateral()`.  If zero, then keeper calls `getCollateralBought()` first.

This status is cached in the keeper so it will only call `lastReadRedemptionPrice` once in it's lifecycle.