### PR TITLE
upstream changes from makerdao

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If none of these options is given or if the gas API produces no result, the keep
 
 `--gas-initial-multiplier MULTIPLIER` When using an API source for fetching the initial gas price, this tunes the price. It's ignored when you're using `--fixed-gas-price`. In case no strategy is specified it defaults to `1.0`
 
-`--gas-reactive-multiplier MULTIPLIER` Every 30 seconds, a transaction's gas price will be multiplied by this value until it is mined or `--gas-maxiumum` is reached. Not used if `gasPrice` is passed from your bidding model. **NOTE**: [Parity](https://wiki.parity.io/Transactions-Queue#dropping-conditions), as of this writing, requires a minimum gas increase of `1.125` to propagate a transaction replacement; this should be treated as a minimum value unless you want replacements to happen less frequently than 30 seconds \(2+ blocks\). This multiplier defaults to  `1.125` if no other value is given.
+`--gas-reactive-multiplier MULTIPLIER` Every 30 seconds, a transaction's gas price will be multiplied by this value until it is mined or `--gas-maxiumum` is reached. Not used if `gasPrice` is passed from your bidding model. **NOTE**: [Parity](https://wiki.parity.io/Transactions-Queue#dropping-conditions), as of this writing, requires a minimum gas increase of `1.125` to propagate a transaction replacement; this should be treated as a minimum value unless you want replacements to happen less frequently. This multiplier defaults to  `1.125` if no other value is given.
 
 `--gas-maximum GWEI` Maximum value for gas price
 

--- a/auction_keeper/gas.py
+++ b/auction_keeper/gas.py
@@ -83,7 +83,7 @@ class DynamicGasPrice(NodeAwareGasPrice):
             initial_price = int(round(fast_price * self.initial_multiplier))
 
         return GeometricGasPrice(initial_price=initial_price,
-                                 every_secs=30,
+                                 every_secs=42,
                                  coefficient=self.reactive_multiplier,
                                  max_price=self.gas_maximum).get_gas_price(time_elapsed)
 

--- a/auction_keeper/main.py
+++ b/auction_keeper/main.py
@@ -437,7 +437,7 @@ class AuctionKeeper:
                                      f"min_lot={self.min_collateral_lot}")
                     continue
                 else:
-                    self._run_future(self.liquidation_engine.liquidate_safe(collateral_type, safe).transact_async(gas_price=self.gas_price))
+                    self.liquidation_engine.liquidate_safe(collateral_type, safe).transact(gas_price=self.gas_price)
 
         self.logger.info(f"Checked {len(safes)} safes in {(datetime.now()-started).seconds} seconds")
         # LiquidationEngine.liquidate implicitly starts the collateral auction; no further action needed.

--- a/auction_keeper/main.py
+++ b/auction_keeper/main.py
@@ -29,7 +29,7 @@ from requests.exceptions import RequestException
 from typing import Optional
 from web3 import Web3
 
-from pyflex import Address, web3_via_http
+from pyflex import Address, get_pending_transactions, web3_via_http 
 from pyflex.deployment import GfDeployment
 from pyflex.keys import register_keys
 from pyflex.lifecycle import Lifecycle
@@ -344,6 +344,8 @@ class AuctionKeeper:
 
         logging.info(f"Keeper will use {self.gas_price} for transactions and bids unless model instructs otherwise")
 
+        self.plunge()
+
     def approve(self):
         if self.arguments.swap_collateral:
             self.syscoin_eth_uniswap.approve(self.token_syscoin)
@@ -359,6 +361,16 @@ class AuctionKeeper:
         time.sleep(1)
         if self.collateral:
             self.collateral.approve(self.our_address, gas_price=self.gas_price)
+
+    def plunge(self):
+        pending_txes = get_pending_transactions(self.web3)
+        if len(pending_txes) > 0:
+            while len(pending_txes) > 0:
+                logging.warning(f"Cancelling first of {len(pending_txes)} pending transactions")
+                pending_txes[0].cancel(gas_price=self.gas_price)
+                # After the synchronous cancel, wait to see if subsequent transactions get mined
+                time.sleep(28)
+                pending_txes = get_pending_transactions(self.web3)
 
     def shutdown(self):
         with self.auctions_lock:
@@ -399,8 +411,10 @@ class AuctionKeeper:
         self.logger.debug(f"Evaluating {len(safes)} {self.collateral_type} safes to be liquidated if any are critical")
 
         for safe in safes.values():
-            is_critical = safe.locked_collateral * collateral_type.liquidation_price < safe.generated_debt * rate
-            if is_critical:
+            if self.is_shutting_down():
+                return
+
+            if self.liquidation_engine.can_liquidate(collateral_type, safe):
                 # If flash swap enabled, use flash proxy to liquidate and settle
                 if self.arguments.flash_swap and self.arguments.bid_on_auctions:
                     saviour = self.liquidation_engine.safe_saviours(collateral_type, safe.address)

--- a/auction_keeper/strategy.py
+++ b/auction_keeper/strategy.py
@@ -165,7 +165,7 @@ class SurplusAuctionStrategy(Strategy):
                       block_time=block_time(self.surplus_auction_house.web3),
                       bid_expiry=bid.bid_expiry,
                       auction_deadline=bid.auction_deadline,
-                      price=Wad(bid.amount_to_sell / Rad(bid.bid_amount)) if bid.bid_amount != Wad(0) else None)
+                      price=Wad(bid.amount_to_sell / Rad(bid.bid_amount)) if bid.bid_amount > Wad.from_number(0.000001) else None)
 
     def bid(self, id: int, price: Wad) -> Tuple[Optional[Wad], Optional[Transact], Optional[Rad]]:
         assert isinstance(id, int)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -355,6 +355,7 @@ def liquidate(geb: GfDeployment, c: Collateral, critical_safe: SAFE) -> int:
     assert isinstance(c, Collateral)
     assert isinstance(critical_safe, SAFE)
 
+    assert geb.liquidation_engine.can_liquidate(critical_safe.collateral_type, critical_safe)
     assert geb.liquidation_engine.liquidate_safe(critical_safe.collateral_type, critical_safe).transact()
     liquidations = geb.liquidation_engine.past_liquidations(1)
     assert len(liquidations) == 1

--- a/tests/manual_test_safe_history.py
+++ b/tests/manual_test_safe_history.py
@@ -43,15 +43,6 @@ rate = collateral_type.accumulated_rate
 
 from_block = geb.starting_block_number
 
-def wait(minutes_to_wait: int, sh: SAFEHistory):
-    while minutes_to_wait > 0:
-        state_update_started = datetime.now()
-        time.sleep(2)
-        print(f"Testing cache for another {minutes_to_wait:.2f} minutes")
-        sh.get_safes()
-        minutes_elapsed = (datetime.now() - state_update_started).seconds / 60
-        minutes_to_wait -= minutes_elapsed
-
 # Retrieve data from chain
 started = datetime.now()
 print(f"Connecting to node...")
@@ -66,8 +57,6 @@ for safe in safes_graph.values():
     if is_critical:
         print(f"critical: {safe}")
 """
-
-wait(1, sh)
 
 # Retrieve data from the Graph
 started = datetime.now()

--- a/tests/random_bid.py
+++ b/tests/random_bid.py
@@ -7,8 +7,7 @@ max_price = float(sys.argv[1]) if len(sys.argv) > 1 else 1000
 
 for line in sys.stdin:
     signal = json.loads(line)
-    auction_id = signal['id']
-    assert isinstance(auction_id, int)
+    auction_id = int(signal['id'])
 
     random.seed(a=auction_id)
     price = max_price * random.random()

--- a/tests/test_gas.py
+++ b/tests/test_gas.py
@@ -29,6 +29,7 @@ import time
 
 GWEI = 1000000000
 default_max_gas = 2000
+every_secs = 42
 
 class TestGasStrategy:
     def teardown_class(self):
@@ -148,10 +149,10 @@ class TestGasStrategy:
 
         default_initial_gas = get_node_gas_price(web3)
         assert keeper.gas_price.get_gas_price(0) == default_initial_gas
-        assert keeper.gas_price.get_gas_price(31) == default_initial_gas * 1.125
-        assert keeper.gas_price.get_gas_price(61) == default_initial_gas * 1.125 ** 2
-        assert keeper.gas_price.get_gas_price(91) == default_initial_gas * 1.125 ** 3
-        assert keeper.gas_price.get_gas_price(30*80) == default_max_gas * GWEI
+        assert keeper.gas_price.get_gas_price(1 + every_secs) == default_initial_gas * 1.125
+        assert keeper.gas_price.get_gas_price(1 + every_secs * 2) == default_initial_gas * 1.125 ** 2
+        assert keeper.gas_price.get_gas_price(1 + every_secs * 3) == default_initial_gas * 1.125 ** 3
+        assert keeper.gas_price.get_gas_price(every_secs * 80) == default_max_gas * GWEI
 
     @pytest.mark.skip("This doesn't account for different initial_amounts in our testchains")
     def test_no_api_non_fixed(self, geb, keeper_address):
@@ -167,10 +168,10 @@ class TestGasStrategy:
                                          f"--model ./bogus-model.sh"), web3=geb.web3)
         initial_amount = get_node_gas_price(geb.web3)
         assert keeper.gas_price.get_gas_price(0) == initial_amount
-        assert keeper.gas_price.get_gas_price(31) == initial_amount * reactive_multipler
-        assert keeper.gas_price.get_gas_price(61) == initial_amount * reactive_multipler ** 2
-        assert keeper.gas_price.get_gas_price(91) == initial_amount * reactive_multipler ** 3
-        assert keeper.gas_price.get_gas_price(30*12) == default_max_gas * GWEI
+        assert keeper.gas_price.get_gas_price(1 + every_secs) == initial_amount * reactive_multipler
+        assert keeper.gas_price.get_gas_price(1 + every_secs * 2) == initial_amount * reactive_multipler ** 2
+        assert keeper.gas_price.get_gas_price(1 + every_secsi * 3) == initial_amount * reactive_multipler ** 3
+        assert keeper.gas_price.get_gas_price(every_secs * 12) == default_max_gas * GWEI
 
     def test_fixed_with_explicit_max(self, web3, keeper_address):
         keeper = AuctionKeeper(args=args(f"--eth-from {keeper_address} "
@@ -185,10 +186,10 @@ class TestGasStrategy:
         assert keeper.gas_price.gas_maximum == 4000 * GWEI
 
         assert keeper.gas_price.get_gas_price(0) == 100 * GWEI
-        assert keeper.gas_price.get_gas_price(31) == 100 * GWEI * 1.125
-        assert keeper.gas_price.get_gas_price(61) == 100 * GWEI * 1.125 ** 2
-        assert keeper.gas_price.get_gas_price(91) == 100 * GWEI * 1.125 ** 3
-        assert keeper.gas_price.get_gas_price(60*30) == 4000 * GWEI
+        assert keeper.gas_price.get_gas_price(1 + every_secs) == 100 * GWEI * 1.125
+        assert keeper.gas_price.get_gas_price(1 + every_secs * 2) == 100 * GWEI * 1.125 ** 2
+        assert keeper.gas_price.get_gas_price(1 + every_secs * 3) == 100 * GWEI * 1.125 ** 3
+        assert keeper.gas_price.get_gas_price(every_secs * 60) == 4000 * GWEI
 
     def test_config_negative(self, web3, keeper_address):
         with pytest.raises(SystemExit):


### PR DESCRIPTION
- Pending txs are now cancelled on startup
- Initial node gas price is now multiplied by `--gas-initial-multiplier`
- `liquidate_safe` is now called synchronously.
- bug fix for small surplus bids
- tweaks on gas testing
- `DynamicGasPrice` default interval changed from `30` to `42`